### PR TITLE
Solve a problem created by a change in Java internals and an old version of lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.36</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/src/main/java/io/github/shuoros/peoplify/model/enumeration/Language.java
+++ b/src/main/java/io/github/shuoros/peoplify/model/enumeration/Language.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public enum Language {
 
     ENGLISH,
+	QUEBEC,
     PERSIAN;
 
     @JsonValue

--- a/src/main/java/io/github/shuoros/peoplify/model/enumeration/Language.java
+++ b/src/main/java/io/github/shuoros/peoplify/model/enumeration/Language.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 public enum Language {
 
     ENGLISH,
-	QUEBEC,
+    QUEBEC,
     PERSIAN;
 
     @JsonValue


### PR DESCRIPTION
The details of the bug are here: https://howtodoinjava.com/lombok/lombok-nosuchfielderror-error/

I was able to compile with the correction in this commit (specifying the lombok version) on MacOS and then run the server fine on my local machine. The tests were all fine, but I am not used to neither Java as a language or Maven as a make system.

I also added a bunch of names from Québec, and modified the Language enumeration for the server side to still work. I was able to compile and use the api correctly. The sources for the names and the reason why they are not just identified as «French» are described in the commit messages.